### PR TITLE
Widget | CSS: Remove padding from widget div

### DIFF
--- a/js/widget.css
+++ b/js/widget.css
@@ -89,3 +89,8 @@
 	width: 15px;
 	height: 30px;
 }
+
+/* Widget output div has a 8px left and right padding which looks off */
+.cell-output-ipywidget-background {
+	padding: 0 !important;
+}


### PR DESCRIPTION
Widget will take full cell width after this fix:

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/36e6b609-61d5-4957-9a88-aab98efa5032" />
